### PR TITLE
Improved .gitignore to ignore all downloaded packages, not only *_msgs.

### DIFF
--- a/.gitignore.static
+++ b/.gitignore.static
@@ -1,4 +1,5 @@
 .gradle
+.gitignore
 build
 *_msgs*
 !rosjava_test_msgs

--- a/jenkins/reindex_release_message_dependencies
+++ b/jenkins/reindex_release_message_dependencies
@@ -88,6 +88,8 @@ if __name__ == "__main__":
             f.write(contents)
         with open(package_xml_path, 'w') as f:
             f.write(new_package_xml)
+        # update .gitignore with all the packages from package.list
+        os.system('cat .gitignore.static package.list | awk \'{print $1;}\' > .gitignore')
         console.pretty_println("package.xml and package.list updated.\n")
         sys.exit(1)  # drop out with failure so I get an email (until I can automate a rosdistro pull request).
         


### PR DESCRIPTION
The .gitignore file is recreated after jenkins/reindex_release_message_dependencies is run and is not a part of the repository to decrease the number of changes introduced by every run of the reindexing.
