### PR TITLE
- change to gradle 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(rosjava_messages)
 
 find_package(catkin REQUIRED rosjava_build_tools)
 
-catkin_rosjava_setup(publishMavenJavaPublicationToMavenRepository)
+catkin_rosjava_setup(publishMavenJavaPublicationToMavenRepository distclean)
 
 catkin_package()
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.2.1'
+  gradleVersion = '2.3'
 }
 
 buildscript {
@@ -46,6 +46,12 @@ apply plugin: 'catkin'
 project.catkin.tree.generate()
 
 allprojects {
+
+    repositories {
+        maven {
+            url "https://repo.jfrog.org/artifactory/libs-releases/"
+        }
+    }
     group 'org.ros.rosjava_messages'
     version = project.catkin.pkg.version
 }
@@ -62,4 +68,4 @@ task distclean << {
     }
 }
 
-defaultTasks 'publishMavenJavaPublicationToMavenRepository'
+defaultTasks 'publishMavenJavaPublicationToMavenRepository', 'distclean'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/package.xml
+++ b/package.xml
@@ -281,6 +281,14 @@
   <build_depend>map_msgs</build_depend>
   <build_depend>grasping_msgs</build_depend>
   <build_depend>roseus</build_depend>
+    <build_depend>cafe_msgs</build_depend>
+    <build_depend>rocon_demo_msgs</build_depend>
+    <build_depend>simple_media_msgs</build_depend>
+    <build_depend>simple_annotation_msgs</build_depend>
+    <build_depend>vending_machine_msgs</build_depend>
+    <build_depend>simple_delivery_msgs</build_depend>
+    <build_depend>waiterbot_msgs</build_depend>
+    <build_depend>ar_track_alvar_msgs</build_depend>
 
 
   <run_depend>rosjava_build_tools</run_depend>

--- a/rosjava_test_msgs/build.gradle
+++ b/rosjava_test_msgs/build.gradle
@@ -29,3 +29,12 @@ try {
 dependencies {
   compile project(':std_msgs')
 }
+
+//fix from http://forums.gradle.org/gradle/topics/repackage_jar_as_bundle
+//noinspection GroovyAssignabilityCheck
+classes {
+    doLast {
+        // without this, the jar task fails with "java.lang.IllegalArgumentException: A Jar can only accept a valid file or directory:" as underlying cause
+        ant.mkdir(dir: "$buildDir/classes/main")
+    }
+}


### PR DESCRIPTION
- change to gradle 2.3
- add .gitignore
- add maven url of [repo.jfrog.org](http://repo.jfrog.org/artifactory/libs-releases/org/apache/commons/com.springsource.org.apache.commons.lang/) for take com.springsource.org.apache.commons.lang from there.
- add distclean after compile and publish. it clean the repo and more easy to handle it like that.
- fix error "java.lang.IllegalArgumentException: A Jar can only accept a valid file or directory". for rosjava_test_msgs compile with gradlew.
- add rocon_demo_msgs messages from here:  
  https://github.com/robotics-in-concert/rocon_demo_msgs  
  include:  
  - cafe_msgs
  - rocon_demo_msgs
  - simple_annotation_msgs
  - simple_delivery_msgs
  - simple_media_msgs
  - vending_machine_msgs
  - waiterbot_msgs
- add ar_track_alvar_msgs from here:
  https://github.com/sniekum/ar_track_alvar_msgs
