### PR TITLE
Temporarily disable unreleased map_store dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -44,7 +44,9 @@
   <build_depend>rocon_tutorial_msgs</build_depend>
   <build_depend>scheduler_msgs</build_depend>
   <build_depend>world_canvas_msgs</build_depend>
+  <!-- Disabled until it is released for kinetic
   <build_depend>map_store</build_depend>                # ros-planning/map_store
+  -->
   <build_depend>move_base_msgs</build_depend>           # ros-planning/navigation
 
   <!-- Temporary requirement so move_base_msgs compiles - remove once


### PR DESCRIPTION
map_store isn't released for kinetic yet and thus it fails to be found as a binary dependency. 
This package is only used by `android_apps` which is not going to be released on this first pass so I think it should be OK to just disable it for now. 

If it becomes necessary later it can be either pulled from sources or the maintainer nudged / helped to release to kinetic (hopefully also separating between msgs and code packages)